### PR TITLE
[fix]修复策略target_pos策略变量显示不及的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/

--- a/vnpy_ctastrategy/template.py
+++ b/vnpy_ctastrategy/template.py
@@ -421,8 +421,10 @@ class TargetPosTemplate(CtaTemplate):
 
     def set_target_pos(self, target_pos):
         """"""
-        self.target_pos = target_pos
-        self.trade()
+        if target_pos != self.target_pos:
+            self.target_pos = target_pos
+            self.put_event()
+            self.trade()
 
     def trade(self):
         """"""


### PR DESCRIPTION
现象
target_pos策略在初始化过程中，点击初始化后，target_pos与pos相等，但是点击 “启动”以后又不相等的情况

![image](https://user-images.githubusercontent.com/28781481/137091447-1f750f43-f1d6-436a-b832-f8834ac80511.png)



原因
target_pos重新计算后，如果与原来不相等，并没有主动去触发更新变量数据的事件(EVENT_CTA_STRATEGY)


解决
target_pos变化时，主动触发更新变量数据事件EVENT_CTA_STRATEGY

修改文件 template.py  中的  TargetPosTemplate 类