### PR TITLE
init_strategy返回Future，这样开发者可以自主决定是否需要等待

### DIFF
--- a/vnpy_ctastrategy/engine.py
+++ b/vnpy_ctastrategy/engine.py
@@ -667,7 +667,7 @@ class CtaEngine(BaseEngine):
         """
         Init a strategy.
         """
-        self.init_executor.submit(self._init_strategy, strategy_name)
+        return self.init_executor.submit(self._init_strategy, strategy_name)
 
     def _init_strategy(self, strategy_name: str):
         """
@@ -872,8 +872,10 @@ class CtaEngine(BaseEngine):
     def init_all_strategies(self):
         """
         """
+        futures = {}
         for strategy_name in self.strategies.keys():
-            self.init_strategy(strategy_name)
+            futures[strategy_name] = self.init_strategy(strategy_name)
+        return futures
 
     def start_all_strategies(self):
         """


### PR DESCRIPTION
在[参考代码no_ui](https://github.com/vnpy/vnpy/blob/0b4f23a57d2e0a18a1a42be0213c7239d65d0959/examples/no_ui/run.py#L81
)当中使用了
```
    cta_engine.init_all_strategies()
    sleep(60)   # Leave enough time to complete strategy initialization
```
如果直接返回Futures，开发者可以直接调用[Futures.result()](https://docs.python.org/zh-cn/3/library/concurrent.futures.html#concurrent.futures.Future.result)来等待子线程完成，不必硬编码60秒。