### PR TITLE
完善两个策略加载过程中的处理逻辑，减少vnpy主进程的重启操作

### DIFF
--- a/vnpy_ctastrategy/engine.py
+++ b/vnpy_ctastrategy/engine.py
@@ -616,17 +616,22 @@ class CtaEngine(BaseEngine):
         """
         Call function of a strategy and catch any exception raised.
         """
+        status = False
         try:
             if params:
                 func(params)
             else:
                 func()
+            
+            status = True
         except Exception:
             strategy.trading = False
             strategy.inited = False
 
             msg: str = f"触发异常已停止\n{traceback.format_exc()}"
             self.write_log(msg, strategy)
+
+        return status
 
     def add_strategy(
         self, class_name: str, strategy_name: str, vt_symbol: str, setting: dict
@@ -683,8 +688,9 @@ class CtaEngine(BaseEngine):
         self.write_log(f"{strategy_name}开始执行初始化")
 
         # Call on_init function of strategy
-        self.call_strategy_func(strategy, strategy.on_init)
-
+        status = self.call_strategy_func(strategy, strategy.on_init)
+        if(status == False):
+            return
         # Restore strategy data(variables)
         data: Optional[dict] = self.strategy_data.get(strategy_name, None)
         if data:

--- a/vnpy_ctastrategy/engine.py
+++ b/vnpy_ctastrategy/engine.py
@@ -630,7 +630,8 @@ class CtaEngine(BaseEngine):
 
             msg: str = f"触发异常已停止\n{traceback.format_exc()}"
             self.write_log(msg, strategy)
-
+            self.put_strategy_event(strategy)
+            
         return status
 
     def add_strategy(
@@ -800,11 +801,10 @@ class CtaEngine(BaseEngine):
     def reload_strategy(self, strategy_name: str) -> bool:
         '''
         reload strategy class
+        - 在非交易状态下都可使用 硬重载 按钮重新加载策略类。
+        - 使用该策略类的所有策略实例都会被重新加载
         '''
         strategy_class: CtaTemplate = self.strategies[strategy_name]
-        if not strategy_class.inited:
-            self.write_log(f"{strategy_class.__module__} 还未进行过初始化")
-            return
         
         has_another_inst: bool = False
         for strategy_key, strategy_val in self.strategies.items():

--- a/vnpy_ctastrategy/ui/widget.py
+++ b/vnpy_ctastrategy/ui/widget.py
@@ -240,8 +240,8 @@ class StrategyManager(QtWidgets.QFrame):
         self.remove_button: QtWidgets.QPushButton = QtWidgets.QPushButton("移除")
         self.remove_button.clicked.connect(self.remove_strategy)
 
-        self.remove_button: QtWidgets.QPushButton = QtWidgets.QPushButton("硬重载")
-        self.remove_button.clicked.connect(self.reload_strategy)
+        self.reload_button: QtWidgets.QPushButton = QtWidgets.QPushButton("硬重载")
+        self.reload_button.clicked.connect(self.reload_strategy)
 
         strategy_name: str = self._data["strategy_name"]
         vt_symbol: str = self._data["vt_symbol"]
@@ -263,6 +263,7 @@ class StrategyManager(QtWidgets.QFrame):
         hbox.addWidget(self.stop_button)
         hbox.addWidget(self.edit_button)
         hbox.addWidget(self.remove_button)
+        hbox.addWidget(self.reload_button)
 
         vbox: QtWidgets.QVBoxLayout = QtWidgets.QVBoxLayout()
         vbox.addWidget(label)
@@ -284,7 +285,14 @@ class StrategyManager(QtWidgets.QFrame):
         trading: bool = variables["trading"]
 
         if not inited:
+            # init or for strategy crashed
+            self.init_button.setEnabled(True)
+            self.start_button.setEnabled(False)
+            self.stop_button.setEnabled(False)
+            self.edit_button.setEnabled(True)
+            self.remove_button.setEnabled(True)
             return
+            
         self.init_button.setEnabled(False)
 
         if trading:

--- a/vnpy_ctastrategy/ui/widget.py
+++ b/vnpy_ctastrategy/ui/widget.py
@@ -240,6 +240,9 @@ class StrategyManager(QtWidgets.QFrame):
         self.remove_button: QtWidgets.QPushButton = QtWidgets.QPushButton("移除")
         self.remove_button.clicked.connect(self.remove_strategy)
 
+        self.remove_button: QtWidgets.QPushButton = QtWidgets.QPushButton("硬重载")
+        self.remove_button.clicked.connect(self.reload_strategy)
+
         strategy_name: str = self._data["strategy_name"]
         vt_symbol: str = self._data["vt_symbol"]
         class_name: str = self._data["class_name"]
@@ -326,6 +329,11 @@ class StrategyManager(QtWidgets.QFrame):
         # Only remove strategy gui manager if it has been removed from engine
         if result:
             self.cta_manager.remove_strategy(self.strategy_name)
+
+
+    def reload_strategy(self) -> None:
+        """"""
+        result: bool = self.cta_engine.reload_strategy(self.strategy_name)
 
 
 class DataMonitor(QtWidgets.QTableWidget):


### PR DESCRIPTION
1。 修复一个体验不好的逻辑：策略在初始化或点启动时如果出现异常需要重启整个vnpy的进程问题。
       现在改成了如果异常时不会继续向下初始化。不设置strategy.inited 状态。 界面上的初始化按钮可重复点击。
       
 2。 添加一个新的功能：不需要重启vnpy的情况下可直接重新刷新策略类的代码逻辑。
       这样在调试策略时就不需要每次都重启vnpy