### PR TITLE
[Fix] 将 TargetPosTemplate 等以Template结尾的类从策略列表里剔除

### DIFF
--- a/vnpy_ctastrategy/engine.py
+++ b/vnpy_ctastrategy/engine.py
@@ -814,7 +814,7 @@ class CtaEngine(BaseEngine):
 
             for name in dir(module):
                 value = getattr(module, name)
-                if (isinstance(value, type) and issubclass(value, CtaTemplate) and value is not CtaTemplate):
+                if (isinstance(value, type) and issubclass(value, CtaTemplate) and not value.__name__.endswith('Template')):
                     self.classes[value.__name__] = value
         except:  # noqa
             msg: str = f"策略文件{module_name}加载失败，触发异常：\n{traceback.format_exc()}"


### PR DESCRIPTION
将所有类名以Template结尾的CtaTemplate子类过滤，避免策略模板被加载到策略列表里去。