### PR TITLE
[Fix]修正变量daily_trade_count的类型

### DIFF
--- a/vnpy_ctastrategy/backtesting.py
+++ b/vnpy_ctastrategy/backtesting.py
@@ -317,7 +317,7 @@ class BacktestingEngine:
         total_turnover: float = 0
         daily_turnover: float = 0
         total_trade_count: int = 0
-        daily_trade_count: int = 0
+        daily_trade_count: float = 0
         total_return: float = 0
         annual_return: float = 0
         daily_return: float = 0


### PR DESCRIPTION
实际上daily_trade_count的类型是float，虽然python不会报错，但既然发现了就修复吧。